### PR TITLE
Create google-cloud-sdk image from scratch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,49 @@
-FROM google/cloud-sdk:slim
+FROM debian:jessie-slim
+LABEL maintainer "Mercari, Inc"
 
+ENV GOPATH=/go \
+	PATH=/go/bin:/usr/local/go/bin:/usr/lib/google-cloud-sdk/bin:/usr/lib/google-cloud-sdk/platform/google_appengine:$PATH
+
+ARG APT_MIRROR=httpredir.debian.org
 ARG GOLANG_VERSION=1.6.4
 ARG GOLANG_DOWNLOAD_SHA256=b58bf5cede40b21812dfa031258db18fc39746cc0972bc26dae0393acc377aaf
-ARG APPENGINE_GO_VERSION=1.9.57
-ARG APPENGINE_GO_DOWNLOAD_SHA256=bd4136de7ef8a5001ca1050238999e9ff45d696ffcb60c4f5e851687dd8deee7
-ENV GOPATH=/go \
-	PATH=/go/bin:/usr/local/go/bin:/google-cloud-sdk/platform/go_appengine:$PATH
 
-RUN set -eux && \
+RUN sed -ri "s/(deb|httpredir).debian.org/${APT_MIRROR}/g" /etc/apt/sources.list && \
+	set -eux && \
 	apt-get update && \
 	apt-get install -yqq --no-install-suggests --no-install-recommends \
+		curl \
 		make \
+		openssh-client \
+		python-dev \
+		python-pip \
+		git \
 		unzip && \
 	rm -rf /var/lib/apt/lists/* && \
+	\
+	pip install -U crcmod && \
+	rm -rf $HOME/.cache/pip && \
+	\
+	curl https://sdk.cloud.google.com | bash -s -- --disable-prompts --install-dir=/usr/lib && \
+	gcloud config set core/disable_usage_reporting true && \
+	gcloud config set component_manager/disable_update_check true && \
+	gcloud config set metrics/environment github_docker_image && \
+	\
+	gcloud components install \
+		app-engine-go \
+		beta \
+		cloud-datastore-emulator \
+		emulator-reverse-proxy \
+		pubsub-emulator && \
+	\
+	chmod +x \
+		/usr/lib/google-cloud-sdk/platform/google_appengine/goapp \
+		/usr/lib/google-cloud-sdk/platform/google_appengine/godoc \
+		/usr/lib/google-cloud-sdk/platform/google_appengine/gofmt && \
 	\
 	curl -o go.tgz -sSL "https://golang.org/dl/go${GOLANG_VERSION}.linux-amd64.tar.gz" && \
 	echo "${GOLANG_DOWNLOAD_SHA256} *go.tgz" | sha256sum -c - && \
 	tar -C /usr/local -xzf go.tgz && \
-	rm go.tgz && \
-	\
-	mkdir -p /google-cloud-sdk/platform && \
-	curl -o gae.zip -sSL "https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-${APPENGINE_GO_VERSION}.zip" && \
-	echo "${APPENGINE_GO_DOWNLOAD_SHA256} *gae.zip" | sha256sum -c - && \
-	unzip -q gae.zip -d /google-cloud-sdk/platform/ && \
-	rm gae.zip
+	rm go.tgz
+
+VOLUME ["/root/.config"]


### PR DESCRIPTION
Create google-cloud-sdk image from scratch. Instead of using `google/cloud-sdk` image.

I planned to manage the `goapp` version, but `gcloud` does not have specific components install feature.
And, If expand `google_appengine_1.9.59.zip` to `/usr/lib/google-cloud-sdk/platform/google_appengine`,  some files are duplicate (need overwrite). It migth be distraction the `gcloud` core components.

So, I'd just install `gcloud` use `curl` and `bash` one-liner(avoid `apt-get`) , and install some components uses `gcloud` way.